### PR TITLE
Fix arrow keys and backspace in REPL

### DIFF
--- a/mu/repl.py
+++ b/mu/repl.py
@@ -46,7 +46,6 @@ class REPLPane(QTextEdit):
         self.serial.setBaudRate(115200)
         print(self.serial.open(QIODevice.ReadWrite))
         self.serial.readyRead.connect(self.on_serial_read)
-        self.serial_input_buffer = b''
 
         # clear the text
         self.clear()
@@ -55,9 +54,9 @@ class REPLPane(QTextEdit):
         self.process_bytes(bytes(self.serial.readAll()))
 
     def keyPressEvent(self, data):
-        text = data.text()
-        msg = bytes(text, 'utf8')
         key = data.key()
+        msg = bytes(data.text(), 'utf8')
+
         if key == Qt.Key_Backspace:
             msg = b'\b'
         elif key == Qt.Key_Up:
@@ -68,59 +67,31 @@ class REPLPane(QTextEdit):
             msg = b'\x1B[C'
         elif key == Qt.Key_Left:
             msg = b'\x1B[D'
+        elif data.modifiers() == Qt.MetaModifier:
+            # Handle the Control key.  I would've expected us to have to test
+            # for Qt.ControlModifier, but on (my!) OSX Qt.MetaModifier does
+            # correspond to the Control key.  I've read something that suggests
+            # that it's different on other platforms.
+            if Qt.Key_A <= key <= Qt.Key_Z:
+                # The microbit treats an input of \x01 as Ctrl+A, etc.
+                msg = bytes([1 + key - Qt.Key_A])
         self.serial.write(msg)
 
     def process_bytes(self, bs):
-        bs = self.serial_input_buffer + bs
-        while len(bs):
-            num_use = 0
-            if bs[0] == 8: # backspace
-                self.delete()
-                num_use = 1
-            elif bs[0] == 13: # \r
-                # ignore
-                num_use = 1
-            elif bs[0] == 27: # escape
-                if bs.startswith(b'\x1b[K'):
-                    # kill to end of line
-                    num_use = 3
-                elif bs.startswith(b'\x1b[') and len(bs) >= 3 and chr(bs[2]).isdigit():
-                    n = bs[2] - ord('0')
-                    cmd_idx = 3
-                    if len(bs) >= 4 and chr(bs[3]).isdigit():
-                        n = 10 * n + bs[3] - ord('0')
-                        cmd_idx = 4
-                    if cmd_idx < len(bs):
-                        if bs[cmd_idx] == ord('D'):
-                            # backspace n chars
-                            for i in range(n):
-                                self.delete()
-                            num_use = cmd_idx + 1
-                if num_use == 0:
-                    # unknown or incomplete escape sequence
-                    print(bs)
+        tc = self.textCursor()
+
+        for b in bs:
+            if b == 8: # \b
+                tc.movePosition(QTextCursor.Left)
+                self.setTextCursor(tc)
+            elif b == 13: # \r
+                pass
             else:
-                self.append(chr(bs[0]))
-                num_use = 1
-            if num_use == 0:
-                break
-            bs = bs[num_use:]
-        self.serial_input_buffer = bs
+                tc.deleteChar()
+                self.setTextCursor(tc)
+                self.insertPlainText(chr(b))
 
-    def append(self, txt):
-        tc = self.textCursor()
-        tc.movePosition(QTextCursor.End)
-        self.setTextCursor(tc)
-        self.insertPlainText(txt)
         self.ensureCursorVisible()
-
-    def delete(self):
-        tc = self.textCursor()
-        tc.deletePreviousChar()
 
     def clear(self):
         self.setText('')
-
-    def kill(self):
-        if self.serial.isOpen():
-            self.serial.close()


### PR DESCRIPTION
Also add support for the control key.  (Although see note about
portability!)

I've deleted some code that appears to handle the escape key, because I
couldn't work out what it was supposed to do, and when I tried out the
escape key via the microrepl, nothing seemed to happen.

Fixes #17.