### PR TITLE
Fix travis deployment from ntoll repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,14 +44,14 @@ deploy:
   provider: s3
   access_key_id: AKIAJYJV7NN6HVHCX5NQ
   secret_access_key:
-  secure: QbXuXL++zQ5ErurkOOsApzwRnRnCwbwA8YVbl5CtkGKuhO9BP7PvJesEbKzIwq3U45uhTpbJ+1kbsCM/4BGlr2z143FsN+s8thieiWR+puJX26tcCDxNl9eFF06tyxvBuXPUWGPaKAX3KwYgangbnk65lSNdaCOfbIRHkhTGRjfPBiPBC+1/rtj3wHcQZq0MWZ9MMBR0SLzlZGY1ENhUHI3kKEmb8ZflFWB1a+Va/SxlieOwncl7LLLxRCkUZfl+bH3yz55C/1ppZ0DRjde5HQWWAGKrfKMpxeqFGx7dz+ZeMWrVGbir+VSXxCPljyn9OXT2t1fA+j9toSxiHpEkmqtDs8Eeoiv36QC6qPHJ6Wq/7QcL8QkMPb/Gvm/9Azl/hWSQkx52IJC83JbIQUU1U2bIDBW/djWNkxbPm7xv1V61rPYUOxXEvp8B+6w7kiT4CW8mDcoNHyrhzkhsWOay3uOvULgWPGAOvWwWDQFH51WPGJxxiNkDJuvqYzAmVE9jZnhHHdwU8uj/8Fplg/eUdeH/WICs4LlEjdT51uYy1fE7JUbHEKmke8leSOiEOaVYzEtHDs346X133CYIOnnyHNgjWylocg4IcxuIiW6LBcygu5qUttHzw0P9WBaE7wa+hg+MXzQiNDsVwOewk+pybyUfUDGqwfebuam2cEzsYpo=
+    secure: QHLfRUdFQX+TejhRBkgNvySkaQOskXji+iduIvKRtzvvhyr3QJHKcMNtO426GRFyKhz6sK3shqn4d5iu/m03gtbv+u1pL9pp0J2GEePzQVP8v24q9Y3oxaXaA7Tm7L2vSIrB7uhJvG5D9H0bVL9my61JvXhvySH47jLvhqHH4F9LdPzby1DXds1Z+R4YNMKE0Z4KmNOhiBHkmKdDcp61fZ91gGiScFIjaXvDb50zdGKjXTQy2t4OtFt4kVbTZWijzxKPCSLZkErfcdNNrCNeMEktk6IEV2KVru9XhDNzzslWwwsR1r2hQI39oVULa3fYXK6W7am8WXVZ6cnJB+yBsNWro3Tp5oiNCWSe6fKDEp+Io+qyhZ+R5PSdzhyRYPUHPCIY/fP/dap/4M/MAO3hZFA3mxjK/vUOc6mtMD/wTE659K4/i7PNYtKFndXXpLpYHHaTis44NLZFIxvs9wWG/ljToYDDK20vG317k5TZUZB/6EipW1DeoO/9qBUxgTdfJypp58kcZNvntUVa4ezf/Bx01ZCMFAk234l7+xAFYI7+m9ITqAPlKWI230Ki5ShzyV+kYcI/GS9cT75iok6+zIWWfyQhKUMDYZ1qb/UDM5Gz9RXoIah0UJTjFd4b3bO6Awdrs2V5Vv2EgMWuKDaHs1s3uONH+PGTluROuqFju/s=
   bucket: ardublockly-builds
   skip_cleanup: true
   local-dir: dist/
   upload-dir: microbit/$TRAVIS_OS_NAME
   acl: public_read
   on:
-    repo: carlosperate/mu
+    repo: ntoll/mu
     branch: [master, travis]
 
 notifications:


### PR DESCRIPTION
For now we can have the travis deployment working for linux: http://ardublockly-builds.s3-website-us-west-2.amazonaws.com/?prefix=microbit/linux/ (the executables from the 24th of December are built from this branch).

We still need to update the [osx installation bash file](https://github.com/ntoll/mu/blob/master/package/install_osx.sh) for the travis server to correctly build the mac executable, and I need to look into the Appveyor deployment issue (most likely I'll need to re encrypt the access key, but I need to figure out how to do that for this repository from my appveyor account).