### PR TITLE
Add all tests to travis OS X CI server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,15 @@ before_install:
 
 # Build Mu and time stamp it
 install:
+  - sudo pip3 install -r requirements.txt
+
+# Run the test suit and build the executable with the time stamp in its file name
+script:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make check; fi
   - pyinstaller package/pyinstaller.spec
   - du -sk dist/
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then mv dist/mu dist/mu-$(date '+%Y-%m-%d_%H_%M_%S'); fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then cd dist && zip --symlinks -r mu-$(date '+%Y-%m-%d_%H_%M_%S').zip mu.app && rm -r mu.app && rm mu && cd ..; fi
-
-# Dummy "script" run to stop default trvais build script, unit test should go here
-script:
-  - ls dist/
 
 # Deploy the build version in an S3 bucket
 deploy:

--- a/package/install_linux.sh
+++ b/package/install_linux.sh
@@ -4,6 +4,8 @@ set -ev
 curl -O https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py
 sudo python3 --version
 sudo python3 get-pip.py
+# Remove the get-pip.py downloaded file to exclude it from test checkers
+rm get-pip.py
 sudo pip3 install pyinstaller
 sudo apt-get update
 sudo apt-get install python3-pyqt5 -y


### PR DESCRIPTION
Adding the test to the OS X build.

Currently the linux version fails with pytest, for some reason it looks like it fails to collect the correct files, and falls when trying to parse unrelated files, so the linux `make check` has been temporarily excluded.
https://travis-ci.org/carlosperate/mu/jobs/103223019#L520-L524
https://travis-ci.org/carlosperate/mu/jobs/103223019#L538-L543