### PR TITLE
Fix new location for get-pip.py script in linux ci install.

### DIFF
--- a/package/install_linux.sh
+++ b/package/install_linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ev
 # Ubuntu 14.04 already has Python3 install, use default sudo path version
-curl -O https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py
+curl -O https://bootstrap.pypa.io/get-pip.py
 sudo python3 --version
 sudo python3 get-pip.py
 sudo pip3 install pyinstaller


### PR DESCRIPTION
Issue reported in https://github.com/ntoll/mu/issues/4#issuecomment-173309520, thanks @ntoll for catching that right away.