### PR TITLE
Correct serial configuration order

### DIFF
--- a/mu/interface.py
+++ b/mu/interface.py
@@ -544,8 +544,8 @@ class REPLPane(QTextEdit):
         # open the serial port
         self.serial = QSerialPort(self)
         self.serial.setPortName(port)
-        self.serial.setBaudRate(115200)
         if self.serial.open(QIODevice.ReadWrite):
+            self.serial.setBaudRate(115200)
             self.serial.readyRead.connect(self.on_serial_read)
             # clear the text
             self.clear()


### PR DESCRIPTION
Fixes #75.

Even though the baud rate should be able to be set before opening the port (http://doc.qt.io/qt-5/qserialport.html#baudRate-prop), a few Stack Overflow qserialport answers indicated that it should be set afterwards. Doing this simple change fixes the REPL in the Linux CI-built binaries.

This binary was created on a test branch when debugging this issue, which should now work: https://s3-us-west-2.amazonaws.com/ardublockly-builds/microbit/linux/mu-2016-02-08_23_49_10