### PR TITLE
mu is a 'Development' program

### DIFF
--- a/conf/mu.desktop
+++ b/conf/mu.desktop
@@ -7,6 +7,6 @@ Icon=mu
 TryExec=mu
 Exec=mu
 Terminal=false
-Categories=Application;Qt;
+Categories=Application;Development;
 Keywords=Python;Editor;microbit;micro:bit;
 


### PR DESCRIPTION
Add this to mu.desktop. This has the bonus that mu now appears in a sensible place in Raspbian's menu.

Useful for upcoming pull request to add Debian packaging.