### PR TITLE
Add setuptools to .deb package dependencies.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.1
 
 Package: mu
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, python3-pyqt5, python3-pyqt5.qsci,
-         python3-pyqt5.qtserialport
+Depends: ${misc:Depends}, ${python3:Depends}, python3-setuptools, python3-pyqt5,
+         python3-pyqt5.qsci, python3-pyqt5.qtserialport
 Description: A simple editor for kids, teachers and new programmers.


### PR DESCRIPTION
The `python3-setuptools` needs to be added to the package dependencies as well, otherwise we get:

```
Traceback (most recent call last):
  File "/usr/bin/mu", line 5, in <module>
    from pkg_resources import load_entry_point
```