### PR TITLE
change dark theme to address Github Issue #107

### DIFF
--- a/mu/interface.py
+++ b/mu/interface.py
@@ -161,7 +161,7 @@ class NightTheme(Theme):
     HighlightedIdentifier = Font(color='#ffffff', paper='black')
     Paper = QColor('black')
     Caret = QColor('white')
-    Margin = QColor('#111')
+    Margin = QColor('#333')
 
 
 class PythonLexer(QsciLexerPython):

--- a/mu/resources/css/night.css
+++ b/mu/resources/css/night.css
@@ -8,11 +8,12 @@ QToolButton:hover {
 }
 
 QToolButton {
-    background-color: black;
+    background-color: #333;
 }
 
 QTextEdit {
     background-color: black;
+    border:3px solid #FFF;
     color: white
 }
 
@@ -33,6 +34,6 @@ QSplitter::handle:horizontal {
 }
 
 QToolBar {
-    background: black;
+    background: #333;
     border: 0px;
 }


### PR DESCRIPTION
Improve the dark theme for low/reduced vision users, so the REPL panel is distinct from the code area.
<img width="1023" alt="screen shot 2016-06-03 at 12 19 00 pm" src="https://cloud.githubusercontent.com/assets/4174972/15790305/7e440e5c-2985-11e6-8008-edbf7e81255e.png">