### PR TITLE
fix for github issue #106, the unsafe tab 'close' button

### DIFF
--- a/mu/interface.py
+++ b/mu/interface.py
@@ -310,6 +310,29 @@ class ButtonBar(QToolBar):
                       self.parentWidget()).activated.connect(handler)
 
 
+class FileTabs(QTabWidget):
+    """extend the base class so we can override the removeTab behavior"""
+    def __init__(self):
+        super(FileTabs, self).__init__()
+        self.setTabsClosable(True)
+        self.tabCloseRequested.connect(self.removeTab)
+
+    def removeTab(self, tab_id):
+        """ask the user before closing the file"""
+        window = self.nativeParentWidget()
+        if (window.modified):
+            reply = QMessageBox.warning(self,
+                'Mu',
+                'There is un-saved work, closing the tab will'
+                ' cause you to lose it.',
+                buttons=QMessageBox.Cancel | QMessageBox.Ok,
+                defaultButton=QMessageBox.Cancel
+            )
+            if reply == QMessageBox.Cancel:
+                return
+        super(FileTabs, self).removeTab(tab_id)
+
+
 class Window(QStackedWidget):
     """
     Defines the look and characteristics of the application's main window.
@@ -552,13 +575,10 @@ class Window(QStackedWidget):
         self.widget.setLayout(widget_layout)
 
         self.button_bar = ButtonBar(self.widget)
-        self.tabs = QTabWidget()
-        self.tabs.setTabsClosable(True)
-        self.tabs.tabCloseRequested.connect(self.tabs.removeTab)
 
         widget_layout.addWidget(self.button_bar)
         widget_layout.addWidget(self.splitter)
-
+        self.tabs = FileTabs()
         self.splitter.addWidget(self.tabs)
 
         self.addWidget(self.widget)
@@ -567,6 +587,7 @@ class Window(QStackedWidget):
         self.set_theme(theme)
         self.show()
         self.autosize_window()
+
 
 
 class REPLPane(QTextEdit):

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -590,7 +590,6 @@ class Window(QStackedWidget):
         self.autosize_window()
 
 
-
 class REPLPane(QTextEdit):
     """
     REPL = Read, Evaluate, Print, Loop.

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -320,7 +320,8 @@ class FileTabs(QTabWidget):
     def removeTab(self, tab_id):
         """ask the user before closing the file"""
         window = self.nativeParentWidget()
-        if (window.modified):
+        modified = window.current_tab.isModified()
+        if (modified):
             reply = QMessageBox.warning(self,
                 'Mu',
                 'There is un-saved work, closing the tab will'

--- a/mu/resources/css/night.css
+++ b/mu/resources/css/night.css
@@ -23,10 +23,12 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     background: #333;
+    font-weight: bold;
 }
 
 QTabBar::tab:!selected {
-    background: black;
+    color: black;
+    background: #CCC;
 }
 
 QSplitter::handle:horizontal {
@@ -35,5 +37,17 @@ QSplitter::handle:horizontal {
 
 QToolBar {
     background: #333;
-    border: 0px;
+    border: 0;
+}
+
+QMessageBox {
+    font-size: 14pt;
+    border: 3px solid white;
+}
+QPushButton {
+    background: #fff;
+    color: #000;
+    border: 3px #fff solid;
+    font-size: 14pt;
+    padding:1em;
 }


### PR DESCRIPTION
I had a go at the QT api. This should resolve files being closed without prompting the user to save. It does work correctly with multiple files too.

The styling changes are to fix the dark theme usage to still be high contrast.
<img width="494" alt="screen shot 2016-06-03 at 3 36 41 pm" src="https://cloud.githubusercontent.com/assets/4174972/15794764/43962b24-29a2-11e6-871f-97d5ae8d42c2.png">
