### PR TITLE
Specify pyinstaller 3.1.1 to avoid VC++ redistributable dependency.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,8 @@ install:
   - cmd: pyqt5_installer.exe /S
   - cmd: python -c "import PyQt5"
 
-  # Install python dependencies
-  - cmd: pip install pyinstaller
+  # Install python dependencies (v3.2 has VC++ redistributable dependencies)
+  - cmd: pip install pyinstaller==3.1.1
   - cmd: pip install -r requirements.txt
 
   # Check installed packages again


### PR DESCRIPTION
Tested on a clean Windows 7 32-bit VM. Builds previous to this commit throw the missing dll error, and reverting back to an older version of PyInstaller fixes the issue.

Fixes #110 