### PR TITLE
Adding python module packages to deb dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Standards-Version: 3.9.1
 Package: mu
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}, python3-setuptools, python3-pyqt5,
-         python3-pyqt5.qsci, python3-pyqt5.qtserialport
+         python3-pyqt5.qsci, python3-pyqt5.qtserialport, python3-serial, python3-pep8, pyflakes
 Description: A simple editor for kids, teachers and new programmers.

--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,5 @@ Package: mu
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}, python3-setuptools, python3-pyqt5,
          python3-pyqt5.qsci, python3-pyqt5.qtserialport, python3-serial,
-         python-flake8, python3-pep8
+         python3-pep8, pyflakes
 Description: A simple editor for kids, teachers and new programmers.

--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,6 @@ Standards-Version: 3.9.1
 Package: mu
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}, python3-setuptools, python3-pyqt5,
-         python3-pyqt5.qsci, python3-pyqt5.qtserialport, python3-serial, python3-pep8, pyflakes
+         python3-pyqt5.qsci, python3-pyqt5.qtserialport, python3-serial,
+         python-flake8, python3-pep8
 Description: A simple editor for kids, teachers and new programmers.

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -29,7 +29,11 @@ import webbrowser
 from PyQt5.QtWidgets import QMessageBox
 from PyQt5.QtSerialPort import QSerialPortInfo
 from pyflakes.api import check
-from pycodestyle import StyleGuide, Checker
+# Currently there is no Debian packages for pycodestyle, so fallback to old name
+try:
+    from pycodestyle import StyleGuide, Checker
+except ImportError:
+    from pep8 import StyleGuide, Checker
 from mu.contrib import uflash, appdirs, microfs
 from mu import __version__
 

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -29,7 +29,7 @@ import webbrowser
 from PyQt5.QtWidgets import QMessageBox
 from PyQt5.QtSerialPort import QSerialPortInfo
 from pyflakes.api import check
-# Currently there is no Debian packages for pycodestyle, so fallback to old name
+# Currently there is no pycodestyle deb packages, so fallback to old name
 try:
     from pycodestyle import StyleGuide, Checker
 except ImportError:


### PR DESCRIPTION
Changes made to the deb control file to add the python module packages.

We shouldn't use a post script to "pip install" the modules required, as that would go against the general philosophy of using the OS packaging system. So the modules have to be installed as packages, just as we've been doing with PyQt5.

In this case these are the modules we needed:

pyserial -> [python3-serial](http://packages.ubuntu.com/trusty/python-serial)
pyflakes -> [python3-flake8](http://packages.ubuntu.com/trusty/python3-flake8) 
pycodestyle -> [python3-pep8](http://packages.ubuntu.com/trusty/python3-pep8)

As you can see we are installing the old pep8 named packaged instead of pycodestyle. As this was quite recent rename there is currently no new packages available, so I had to add a `try/except ImportError` to import with one name or the other. Hopefully it will not be that long before it is added and we can revert that to a single line import: https://osdir.com/ml/debian-python/2016-06/msg00041.html

We still need to test this in a Raspberry Pi to see if the packages are also available there.