### PR TITLE
Close unused file descriptor in pycodestyle check.

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -102,7 +102,8 @@ def check_pycodestyle(code):
     """
     # PyCodeStyle reads input from files, so make a temporary file containing
     # the code.
-    _, code_filename = tempfile.mkstemp()
+    code_fd, code_filename = tempfile.mkstemp()
+    os.close(code_fd)
     with open(code_filename, 'w') as code_file:
         code_file.write(code)
     # Configure which PEP8 rules to ignore.


### PR DESCRIPTION
Fixes #117.

In essence, on Windows the temporary file created for the pycodestyle check was not removable as the Python process was keeping it locked.

I've only tested the fix on Windows 10 x64, but it seems like an innocuous enough change to not cause issues in the other platforms (famous last works..).
