### PR TITLE
Maintain OS specific end-of-lines in code files.

### DIFF
--- a/mu/logic.py
+++ b/mu/logic.py
@@ -264,7 +264,7 @@ class Editor:
                             self._view.add_tab(path, text)
         if not self._view.tab_count:
             py = 'from microbit import *{}{}# Write your code here :-)'.format(
-                    os.linesep, os.linesep)
+                os.linesep, os.linesep)
             self._view.add_tab(None, py)
         self._view.set_theme(self.theme)
 

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -103,7 +103,7 @@ def check_pycodestyle(code):
     # PyCodeStyle reads input from files, so make a temporary file containing
     # the code.
     _, code_filename = tempfile.mkstemp()
-    with open(code_filename, 'w') as code_file:
+    with open(code_filename, 'w', newline='\n') as code_file:
         code_file.write(code)
     # Configure which PEP8 rules to ignore.
     style = StyleGuide(parse_argv=False, config_file=False)
@@ -123,7 +123,7 @@ def check_pycodestyle(code):
     os.remove(code_filename)
     # Parse the output from the tool into a list of usefully structured data.
     style_feedback = []
-    for result in results.split('\n'):
+    for result in results.split(os.linesep):
         matcher = STYLE_REGEX.match(result)
         if matcher:
             line_no, col, msg = matcher.groups()
@@ -263,7 +263,8 @@ class Editor:
                         else:
                             self._view.add_tab(path, text)
         if not self._view.tab_count:
-            py = 'from microbit import *\n\n# Write your code here :-)'
+            py = 'from microbit import *{}{}# Write your code here :-)'.format(
+                    os.linesep, os.linesep)
             self._view.add_tab(None, py)
         self._view.set_theme(self.theme)
 
@@ -464,14 +465,14 @@ class Editor:
             if path.endswith('.py'):
                 # Open the file, read the textual content and set the name as
                 # the path to the file.
-                with open(path) as f:
+                with open(path, newline=os.linesep) as f:
                     text = f.read()
                 name = path
             else:
                 # Open the hex, extract the Python script therein and set the
                 # name to None, thus forcing the user to work out what to name
                 # the recovered script.
-                with open(path) as f:
+                with open(path, newline=os.linesep) as f:
                     text = uflash.extract_script(f.read())
                 name = None
         except FileNotFoundError:
@@ -496,7 +497,7 @@ class Editor:
             if not os.path.basename(tab.path).endswith('.py'):
                 # No extension given, default to .py
                 tab.path += '.py'
-            with open(tab.path, 'w') as f:
+            with open(tab.path, 'w', newline='\n') as f:
                 logger.info('Saving script to: {}'.format(tab.path))
                 logger.debug(tab.text())
                 f.write(tab.text())

--- a/mu/logic.py
+++ b/mu/logic.py
@@ -103,7 +103,7 @@ def check_pycodestyle(code):
     # PyCodeStyle reads input from files, so make a temporary file containing
     # the code.
     _, code_filename = tempfile.mkstemp()
-    with open(code_filename, 'w', newline='\n') as code_file:
+    with open(code_filename, 'w', newline='') as code_file:
         code_file.write(code)
     # Configure which PEP8 rules to ignore.
     style = StyleGuide(parse_argv=False, config_file=False)
@@ -465,14 +465,14 @@ class Editor:
             if path.endswith('.py'):
                 # Open the file, read the textual content and set the name as
                 # the path to the file.
-                with open(path, newline=os.linesep) as f:
+                with open(path, newline='') as f:
                     text = f.read()
                 name = path
             else:
                 # Open the hex, extract the Python script therein and set the
                 # name to None, thus forcing the user to work out what to name
                 # the recovered script.
-                with open(path, newline=os.linesep) as f:
+                with open(path, newline='') as f:
                     text = uflash.extract_script(f.read())
                 name = None
         except FileNotFoundError:
@@ -497,7 +497,7 @@ class Editor:
             if not os.path.basename(tab.path).endswith('.py'):
                 # No extension given, default to .py
                 tab.path += '.py'
-            with open(tab.path, 'w', newline='\n') as f:
+            with open(tab.path, 'w', newline='') as f:
                 logger.info('Saving script to: {}'.format(tab.path))
                 logger.debug(tab.text())
                 f.write(tab.text())

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -767,7 +767,7 @@ def test_save_no_path():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w', newline='\n')
+    mock_open.assert_called_once_with('foo.py', 'w', newline='')
     mock_open.return_value.write.assert_called_once_with('foo')
     view.get_save_path.assert_called_once_with(mu.logic.PYTHON_DIRECTORY)
 
@@ -805,7 +805,7 @@ def test_save_python_file():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w', newline='\n')
+    mock_open.assert_called_once_with('foo.py', 'w', newline='')
     mock_open.return_value.write.assert_called_once_with('foo')
     assert view.get_save_path.call_count == 0
     view.current_tab.setModified.assert_called_once_with(False)
@@ -827,7 +827,7 @@ def test_save_with_no_file_extension():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w', newline='\n')
+    mock_open.assert_called_once_with('foo.py', 'w', newline='')
     mock_open.return_value.write.assert_called_once_with('foo')
     assert view.get_save_path.call_count == 0
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -767,7 +767,7 @@ def test_save_no_path():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w')
+    mock_open.assert_called_once_with('foo.py', 'w', newline='\n')
     mock_open.return_value.write.assert_called_once_with('foo')
     view.get_save_path.assert_called_once_with(mu.logic.PYTHON_DIRECTORY)
 
@@ -805,7 +805,7 @@ def test_save_python_file():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w')
+    mock_open.assert_called_once_with('foo.py', 'w', newline='\n')
     mock_open.return_value.write.assert_called_once_with('foo')
     assert view.get_save_path.call_count == 0
     view.current_tab.setModified.assert_called_once_with(False)
@@ -827,7 +827,7 @@ def test_save_with_no_file_extension():
     ed = mu.logic.Editor(view)
     with mock.patch('builtins.open', mock_open):
         ed.save()
-    mock_open.assert_called_once_with('foo.py', 'w')
+    mock_open.assert_called_once_with('foo.py', 'w', newline='\n')
     mock_open.return_value.write.assert_called_once_with('foo')
     assert view.get_save_path.call_count == 0
 


### PR DESCRIPTION
Possibly fixes https://github.com/ntoll/mu/issues/112 and https://github.com/ntoll/mu/issues/85.

At the moment we are having issues processing the Windows end of line format (`\r\n`). In essence scintilla automatically selects the host OS line ending type (as it should), so we have the editor producing `\r\n` endings, and the default saving option in python tries to convert to the native type, replacing each `\n` with `\r\n`, and causing the final format saved as `\r\r\n`. By the default open options, which try to convert windows line endings into single `\n`, this is then read back as `\n\n`.

We should definitely keep compatibility with the Windows format for both opening and saving files.  So the idea is to keep scintilla appending `\r\n`, save the files as they are edited without any modifications, and opening them without converting the windows line ending into single `\n` either.


So I've added the `newline=\n` argument to the each `open()` used to write the editor file. This sets the default line endings as `\n`, which does **not** replace `\n\r` with `\n`, it just leaves them alone. The `open()` calls for reading files have been configured to `newline=os.linesep`, which should maintain the same behaviour on linux/osx and not translate the windows `\r\n` into `\n`.

I have left the settings file alone as all the new lines produced by Python itself should be `\n`  and correctly converted. However we should note that the log file currently copies logs the code every time the file is saved, so this could be revisited in the future.

So, a general question I’ve got is if we are maintining Python2 compatibility at all? The `open(newline=)` argument is Python3 only.
