### PR TITLE
Editor.reset_annotations() line_no correction.

### DIFF
--- a/mu/interface.py
+++ b/mu/interface.py
@@ -282,9 +282,11 @@ class EditorPane(QsciScintilla):
         """
         self.clearAnnotations()
         self.markerDeleteAll()
-        for line_no in self.indicators:
-            self.clearIndicatorRange(line_no, 0, line_no, 999999,
-                                     self.INDICATOR_NUMBER)
+        for marker_id in self.indicators:
+            for message in self.indicators[marker_id]:
+                line_no = int(message['line_no']) - 1  # Mu editor is zero based
+                    self.clearIndicatorRange(line_no, 0, line_no, 999999,
+                                         self.INDICATOR_NUMBER)
         self.indicators = {}
 
     def annotate_code(self, feedback):

--- a/mu/interface.py
+++ b/mu/interface.py
@@ -284,8 +284,8 @@ class EditorPane(QsciScintilla):
         self.markerDeleteAll()
         for marker_id in self.indicators:
             for message in self.indicators[marker_id]:
-                line_no = int(message['line_no']) - 1  # Mu editor is zero based
-                    self.clearIndicatorRange(line_no, 0, line_no, 999999,
+                line_no = int(message['line_no']) - 1  # Mu editor is 0-based
+                self.clearIndicatorRange(line_no, 0, line_no, 999999,
                                          self.INDICATOR_NUMBER)
         self.indicators = {}
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -200,7 +200,7 @@ def test_EditorPane_reset_annotations():
     ep.markerDeleteAll = mock.MagicMock()
     ep.clearIndicatorRange = mock.MagicMock()
     ep.indicators = {
-        1: 'indicator detail',
+        1: [{'line_no': 2, 'column': 0, 'message': 'indicator detail'}],
     }
     ep.reset_annotations()
     ep.clearAnnotations.assert_called_once_with()


### PR DESCRIPTION
The QsciScintilla Editor member `self.indicators` is set in `Editor.annotate_code()` as 

```python
self.indicators[marker_id] = message
```

In this case `message` is a list of dictionaries, each containing the `line_no` (line count starts at value 1), `column`, and `message`.

On `Editor.reset_annotations()` `self.indicators` dictionary is read as if the keys were the line numbers instead of the marker IDs. This PR corrects the `reset_annotation()` implementation.